### PR TITLE
Math operators operator for Decimal and MathResult<Decimal>

### DIFF
--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -619,7 +619,7 @@ try_from_integer!(I192, I256, I512, U192, U256, U512);
 
 #[derive(Debug)]
 pub enum MathResult<T> {
-    Err,
+    Err,  // can be extended with specific error types like Overflow or DivZero
     Ok(T),
 }
 

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -8,6 +8,7 @@ use sbor::rust::fmt;
 use sbor::rust::format;
 use sbor::rust::prelude::*;
 use sbor::*;
+use std::ops::{Add, Div, Mul, Sub};
 
 use crate::data::manifest::ManifestCustomValueKind;
 use crate::data::scrypto::*;
@@ -616,11 +617,85 @@ macro_rules! try_from_integer {
 }
 try_from_integer!(I192, I256, I512, U192, U256, U512);
 
+pub enum MathResult<T> {
+    None,
+    Some(T),
+}
+
+impl<T> MathResult<T> {
+    pub fn unwrap(self) -> T {
+        match self {
+            MathResult::None => panic!("Unwrapping None"),
+            MathResult::Some(value) => value,
+        }
+    }
+
+    pub fn and_then<U, F>(self, f: F) -> MathResult<U>
+    where
+        F: FnOnce(T) -> MathResult<U>,
+    {
+        match self {
+            MathResult::None => MathResult::None,
+            MathResult::Some(value) => f(value),
+        }
+    }
+}
+
+impl<T> From<Option<T>> for MathResult<T> {
+    fn from(opt: Option<T>) -> Self {
+        match opt {
+            Some(value) => MathResult::Some(value),
+            None => MathResult::None,
+        }
+    }
+}
+
+impl Add for Decimal {
+    type Output = MathResult<Decimal>;
+
+    fn add(self, other: Decimal) -> MathResult<Decimal> {
+        self.safe_add(other).into()
+    }
+}
+
+impl Add<MathResult<Decimal>> for Decimal {
+    type Output = MathResult<Decimal>;
+
+    fn add(self, other: MathResult<Decimal>) -> MathResult<Decimal> {
+        other.and_then(|other_| self.safe_add(other_).into())
+    }
+}
+
+impl Add<Decimal> for MathResult<Decimal> {
+    type Output = MathResult<Decimal>;
+
+    fn add(self, other: Decimal) -> MathResult<Decimal> {
+        self.and_then(|self_| self_.safe_add(other).into())
+    }
+}
+
+impl Add<MathResult<Decimal>> for MathResult<Decimal> {
+    type Output = MathResult<Decimal>;
+
+    fn add(self, other: MathResult<Decimal>) -> MathResult<Decimal> {
+        other.and_then(|other_| self.and_then(|self_| self_.safe_add(other_).into()))
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::dec;
     use paste::paste;
+
+    #[test]
+    fn test_math_operators() {
+        let a = dec!(42);
+        let b = dec!(2);
+        let c = dec!("1.5");
+        let result = a + b + c + b;
+    }
 
     #[test]
     fn test_format_decimal() {

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -661,6 +661,15 @@ impl<T: PartialEq> PartialEq<T> for MathResult<T> {
     }
 }
 
+impl PartialEq<MathResult<Decimal>> for Decimal {
+    fn eq(&self, other: &MathResult<Decimal>) -> bool {
+        match other {
+            MathResult::Ok(other_) => self == other_,
+            _ => false,
+        }
+    }
+}
+
 impl<T> From<Option<T>> for MathResult<T> {
     fn from(opt: Option<T>) -> Self {
         match opt {
@@ -920,6 +929,7 @@ mod tests {
         let d = dec!(10);
         let result = a - b + c + b * (d + b / d);
         assert_eq!(result, dec!("61.9"));
+        assert_eq!(dec!("61.9"), result);
     }
 
     #[test]

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -895,7 +895,7 @@ impl DivAssign<MathResult<Decimal>> for MathResult<Decimal> {
 ///
 /// Further details: https://rust-lang.github.io/rfcs/3058-try-trait-v2.html
 #[macro_export]
-macro_rules! mtry {
+macro_rules! q {
     ($expr:expr $(,)?) => {
         match $expr {
             MathResult::Ok(val) => val,
@@ -941,8 +941,8 @@ mod tests {
     }
 
     fn math_calc_test(a: Decimal) -> MathResult<Decimal> {
-        let result1 = mtry!(a + dec!(4));
-        let result2 = mtry!(result1 * dec!(4));
+        let result1 = q!(a + dec!(4));
+        let result2 = q!(result1 * dec!(4));
         let final_result = dec!(30) - result2;
         final_result
     }

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -913,8 +913,8 @@ mod tests {
         result *= dec!(4);
         result /= dec!(2);
         assert_eq!(result, dec!(10));
-        // assigns with MathResult<Decimal>
         let mut result: MathResult<Decimal> = dec!(10).into();
+        // assigns with MathResult<Decimal>
         result += dec!(5) + dec!(5);
         result -= dec!(2) - dec!(1);
         result *= dec!(4) * dec!(3);


### PR DESCRIPTION
First prototype draft for `Add trait` for the new Decimal type.

Other operators like `Sub, Mul, Div` can be added easily (also for `PreciseDecimal` of course).